### PR TITLE
Adds `ptarg` alias

### DIFF
--- a/BashingPartyAnnounce.xml
+++ b/BashingPartyAnnounce.xml
@@ -5,8 +5,6 @@
     <TimerPackage/>
     <AliasPackage>
         <Alias isActive="yes" isFolder="no">
-			<script>if keneanung.bashing.targetList[1] then 
-end</script>
             <name>toggle party announce</name>
             <script>keneanung.bashing.announce = not keneanung.bashing.announce
 cecho(&quot;&lt;green&gt;keneanung:&lt;reset&gt; Party announce is now &lt;red&gt;&quot; .. ( keneanung.bashing.announce and &quot;on&quot; or &quot;off&quot;) .. &quot;&lt;reset&gt;.\n&quot;)</script>

--- a/BashingPartyAnnounce.xml
+++ b/BashingPartyAnnounce.xml
@@ -5,8 +5,22 @@
     <TimerPackage/>
     <AliasPackage>
         <Alias isActive="yes" isFolder="no">
+			<name>announce one target</name>
+			<script>if keneanung.bashing.targetList[1] then 
+  send("pt Target changed to " .. keneanung.bashing.targetList[1].id ,false)
+else 
+  send("pt Target changed to none")
+end</script>
+			<command></command>
+			<packageName></packageName>
+			<regex>^ptarg$</regex>
+		</Alias>
+		<Alias isActive="yes" isFolder="no">
             <name>toggle party announce</name>
             <script>keneanung.bashing.announce = not keneanung.bashing.announce
+if keneanung.bashing.announce then
+  send("pt I am calling targets, focus your fire on my command.",false)
+end
 cecho(&quot;&lt;green&gt;keneanung:&lt;reset&gt; Party announce is now &lt;red&gt;&quot; .. ( keneanung.bashing.announce and &quot;on&quot; or &quot;off&quot;) .. &quot;&lt;reset&gt;.\n&quot;)</script>
             <command></command>
             <packageName></packageName>

--- a/BashingPartyAnnounce.xml
+++ b/BashingPartyAnnounce.xml
@@ -5,6 +5,8 @@
     <TimerPackage/>
     <AliasPackage>
         <Alias isActive="yes" isFolder="no">
+			<script>if keneanung.bashing.targetList[1] then 
+end</script>
             <name>toggle party announce</name>
             <script>keneanung.bashing.announce = not keneanung.bashing.announce
 cecho(&quot;&lt;green&gt;keneanung:&lt;reset&gt; Party announce is now &lt;red&gt;&quot; .. ( keneanung.bashing.announce and &quot;on&quot; or &quot;off&quot;) .. &quot;&lt;reset&gt;.\n&quot;)</script>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ BashingPartyAnnounce.xml
 - announces the ID of the target to the party when switching targets.
 - uses the events the basher emits.
 - toggle on/off with `pt announce`
+- call a single target with `ptarg`
  
 ManuallyAddPossibleTarget.lua
 -----------------------------


### PR DESCRIPTION
Allows for party leader to call just a single target in a room, not auto-switch the entire party to the next target.

Also added standard party leader call.